### PR TITLE
perffile: fix loop scoping bug

### DIFF
--- a/perffile/reader.go
+++ b/perffile/reader.go
@@ -104,6 +104,7 @@ func New(r io.ReaderAt) (*File, error) {
 	// Read EventAttr IDs and create ID -> EventAttr map
 	file.idToAttr = make(map[attrID]*EventAttr)
 	for _, attr := range file.attrs {
+		attr := attr
 		var ids []attrID
 		if err := readSlice(attr.IDs.sectionReader(r), &ids); err != nil {
 			return nil, err


### PR DESCRIPTION
The scoping bug causes incorrect interpretation of perf.data files that include more than one kind of sample, through every entry in File.idToAttr pointing to a single shared value.