### PR TITLE
perfsession: sort dwarfLineTable

### DIFF
--- a/perfsession/symbolize.go
+++ b/perfsession/symbolize.go
@@ -407,5 +407,10 @@ func dwarfLineTable(dwarff *dwarf.Data) []dwarf.LineEntry {
 			out = append(out, lent)
 		}
 	}
+
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Address < out[j].Address
+	})
+
 	return out
 }


### PR DESCRIPTION
findIP assumes that s.linetab is sorted, but dwarfLineTable doesn't currently guarantee that.